### PR TITLE
fix: show bike ID in form when editing an existing record

### DIFF
--- a/stock_velos/templates/_form.tpl
+++ b/stock_velos/templates/_form.tpl
@@ -6,7 +6,11 @@
 	<legend>Général</legend>
 	<dl>
 		<dt>Numéro unique du vélo</dt>
-		<dd>(Sera donné automatiquement à l'enregistrement du vélo.)</dd>
+		{if $velo.id}
+			<dd>{$velo.id}</dd>
+		{else}
+			<dd>(Sera donné automatiquement à l'enregistrement du vélo.)</dd>
+		{/if}
 		{if $fields.etiquette.enabled}
 			{input type="number" name="etiquette" label="Numéro étiquette" required=$fields.etiquette.required source=$velo}
 			{if !$velo.id}


### PR DESCRIPTION
Lorsqu'un vélo existe déjà dans la table, Son numéro n'est pas affiché directement, mais affichage du texte "`(Sera donné automatiquement à l'enregistrement du vélo.)`" :

<img width="762" height="247" alt="bike_id" src="https://github.com/user-attachments/assets/cf8f18d2-74f7-42c0-83f4-06ea504a4b7a" />

Avec ce patch :

<img width="504" height="372" alt="bike_id_fixed" src="https://github.com/user-attachments/assets/6b944ec5-b7db-4587-9312-fc1b2320005a" />

Merci à toute l'équipe de Paheko qui fait un super boulot 