### PR TITLE
fix: hide etiquette from search criteria and display when disabled

### DIFF
--- a/stock_velos/templates/index.tpl
+++ b/stock_velos/templates/index.tpl
@@ -3,17 +3,14 @@
 {include file="./_nav.tpl" current="index"}
 
 <form method="get" action="fiche.php" class="fastFind">
-	<fieldset class="shortFormRight">
-		<legend>Trouver un vélo par numéro unique</legend>
-		<p>
-			<input type="number" size="5" name="id" />
-			<input type="submit" value="Trouver" />
-		</p>
-	</fieldset>
 	<fieldset>
-		<legend>Trouver un vélo par numéro d'étiquette</legend>
+		<legend>Trouver un vélo par numéro {if $fields.etiquette.enabled}d'étiquette{else}unique{/if}</legend>
 		<p>
+			{if $fields.etiquette.enabled}
 			<input type="number" size="5" name="etiquette" />
+			{else}
+			<input type="number" size="5" name="id" />
+			{/if}
 			<input type="submit" value="Trouver" />
 			{linkbutton shape="search" href="recherche.php" label="Recherche avancée"}
 		</p>

--- a/stock_velos/templates/stock.tpl
+++ b/stock_velos/templates/stock.tpl
@@ -8,7 +8,7 @@
 		<h2 class="ruler">{$a_demonter|count} à démonter</h2>
 		<p>
 			{foreach from=$a_demonter item="r"}
-			<a href="fiche.php?id={$r.id}" class="a_demonter">{if $r.etiquette}{$r.etiquette}{else}&#x1F6B2;{/if}</a>
+			<a href="fiche.php?id={$r.id}" class="a_demonter">{if $fields.etiquette.enabled && $r.etiquette}{$r.etiquette}{elseif $r.id}{$r.id}{else}&#x1F6B2;{/if}</a>
 			{/foreach}
 		</p>
 	</article>
@@ -17,7 +17,7 @@
 		<h3>(valeur : {$valeur_vente|escape} €, prix moyen d'un vélo : {$prix_moyen|escape} €)</h3>
 		<p>
 			{foreach from=$en_vente item="r"}
-			<a href="fiche.php?id={$r.id}" class="en_vente">{if $r.etiquette}{$r.etiquette}{else}&#x1F6B2;{/if} <i>{$r.prix}&nbsp;€</i></a>
+			<a href="fiche.php?id={$r.id}" class="en_vente">{if $fields.etiquette.enabled && $r.etiquette}{$r.etiquette}{elseif $r.id}{$r.id}{else}&#x1F6B2;{/if} <i>{$r.prix}&nbsp;€</i></a>
 			{/foreach}
 		</p>
 	</article>
@@ -25,7 +25,7 @@
 		<h2 class="ruler">{$autres|count} divers en stock</h2>
 		<p>
 			{foreach from=$autres item="r"}
-			<a href="fiche.php?id={$r.id}" class="en_stock">{if $r.etiquette}{$r.etiquette}{else}&#x1F6B2;{/if}</a>
+			<a href="fiche.php?id={$r.id}" class="en_stock">{if $fields.etiquette.enabled && $r.etiquette}{$r.etiquette}{elseif $r.id}{$r.id}{else}&#x1F6B2;{/if}</a>
 			{/foreach}
 		</p>
 	</article>


### PR DESCRIPTION
Dans notre association, nos vélos ont un identifiant unique. Paheko propose de ne pas utiliser le champ "etiquette", mais cette fonctionnalité n'est pas complète. Par exemple, si je visualise l'état du stock :

<img width="996" height="698" alt="stock" src="https://github.com/user-attachments/assets/77bafd14-f585-4e42-9628-b99c49f01ac4" />

Le patch fait en sorte d'afficher le numéro unique, si 'etiquette' est désactivé.

Également, la recherche via etiquette ne sera pas proposée si "etiquette" est désactivé :
<img width="818" height="92" alt="recherche1" src="https://github.com/user-attachments/assets/4a18d365-8e7e-475c-a0ca-c4987d2473c0" />

Si "etiquette" est activé, alors le formulaire devient :

<img width="815" height="89" alt="recherche2" src="https://github.com/user-attachments/assets/88159bd9-10bb-458f-8fc4-c90a5ba5e131" />

Ce n'est qu'une proposition de patch, qui pourrait convenir aux associations qui utilisent les numéros uniques, et les autres les étiquettes. à adapter/améliorer ... :-)


