### PR TITLE
fix: remove disabled fields from search criteria dropdown

### DIFF
--- a/stock_velos/admin/recherche.php
+++ b/stock_velos/admin/recherche.php
@@ -15,6 +15,13 @@ $fields = array(
 	'bicycode'       =>  'Bicycode',
 );
 
+$veloFields = $velos->getFields();
+foreach ($fields as $key => $label) {
+	if (isset($veloFields[$key]) && !$veloFields[$key]->enabled) {
+		unset($fields[$key]);
+	}
+}
+
 if (qg('f') && !array_key_exists(qg('f'), $fields))
 {
 	$_GET['f'] = '';


### PR DESCRIPTION
Dans "recherche avancée", est proposé dans la liste déroulante de rechercher par des champs qui peuvent potentiellement être désactivés. Par exemple si "etiquette" est désactivé, je peux toujours rechercher par "étiquette" :

<img width="392" height="349" alt="image-2026-03-23-190820" src="https://github.com/user-attachments/assets/06eafd13-5495-490c-81dd-293697c7ea1e" />

Ce patch supprime de la liste, tous les champs qui seraient désactivés dans la configuration. Il y a peut-être plus propre pour réaliser cette action, mais l'idée est là :-)
